### PR TITLE
Return full voucher on create and check id

### DIFF
--- a/apps/voucher/api/views.py
+++ b/apps/voucher/api/views.py
@@ -69,6 +69,20 @@ class VoucherViewSet(viewsets.ModelViewSet):
             return BulkVoucherCreateSerializer
         return VoucherSerializer
 
+    def create(self, request, *args, **kwargs):
+        """Create a voucher and return the full object with id."""
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        voucher = serializer.save()
+        # Use VoucherSerializer for the response to include all fields including id
+        response_serializer = VoucherSerializer(voucher)
+        headers = self.get_success_headers(response_serializer.data)
+        return Response(
+            response_serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=headers
+        )
+
     @action(detail=False, methods=['get'])
     def active_vouchers(self, request):
         """Return only active vouchers."""

--- a/frontend/src/providers/dataProvider.ts
+++ b/frontend/src/providers/dataProvider.ts
@@ -124,7 +124,15 @@ export const dataProvider: DataProvider = {
   create: async (resource, params) => {
     const url = `/${resource}/`;
     const response = await apiClient.post(url, params.data);
-    return { data: response.data };
+    const data = response.data;
+    
+    // Ensure the response has an id field for React-Admin
+    if (!data.id) {
+      console.error('Create response missing id:', data);
+      throw new Error(`Invalid dataProvider response for create: missing id. Response: ${JSON.stringify(data)}`);
+    }
+    
+    return { data };
   },
 
   // Override update — use PATCH so partial payloads (e.g. drag-to-reorder


### PR DESCRIPTION
Override VoucherViewSet.create to save the voucher and return the full VoucherSerializer (including id) with success headers. Update frontend dataProvider.create to ensure the API create response includes an id (required by React-Admin); log and throw an error if the id is missing.