### PR TITLE
fix: participants could place orders during a program pause (#78)

### DIFF
--- a/apps/account/tasks/order_window.py
+++ b/apps/account/tasks/order_window.py
@@ -40,11 +40,7 @@ def notify_participants_order_window_opened():
 
     # ProgramPause is global — if any pause is active, no program should fire
     # order-window emails (the pause week is a no-order week for all programs).
-    pause_active = ProgramPause.objects.filter(
-        pause_start__lte=now,
-        pause_end__gte=now,
-        archived=False,
-    ).exists()
+    pause_active = ProgramPause.objects.in_progress(at=now).exists()
 
     if pause_active:
         logger.info(

--- a/apps/lifeskills/models.py
+++ b/apps/lifeskills/models.py
@@ -19,7 +19,18 @@ class ProgramPauseQuerySet(models.QuerySet):
     def active(self):
         """Filter queryset to only active pauses."""
         return self.with_annotations().filter(is_active_gate=True)
-    
+
+    def in_progress(self, at=None):
+        """Pauses whose off-week is underway at `at` (default: now).
+
+        Distinct from .active(): the "active gate" matches the pre-pause
+        double-order week (10-14 days before pause_start) and is False
+        during the pause itself. This matches the pause week proper —
+        the no-order week.
+        """
+        at = at or timezone.now()
+        return self.filter(pause_start__lte=at, pause_end__gte=at)
+
     def all_pauses(self):
         """Return all pauses including archived ones."""
         return self.all()

--- a/apps/orders/api/views.py
+++ b/apps/orders/api/views.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.db.models import Count, Sum, Q
 from django.http import HttpResponse
-from django.utils import timezone
+from django.utils import formats, timezone
 from django.utils.translation import gettext as _
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, filters, status, mixins
@@ -549,6 +549,27 @@ class OrderViewSet(viewsets.ModelViewSet):
 
                 # Now run validation
                 violations = []
+
+                # Program pause blocks all ordering during the off week
+                # (Issue #78), unless staff force-opened the program's window.
+                from core.utils import get_active_window_override, get_in_progress_pause
+                in_progress_pause = get_in_progress_pause()
+                if in_progress_pause:
+                    program = getattr(participant, 'program', None)
+                    pause_override = (
+                        get_active_window_override(program) if program else None
+                    )
+                    if not (pause_override and pause_override.force_status == 'open'):
+                        violations.append({
+                            'type': 'window',
+                            'severity': 'error',
+                            'message': _(
+                                "Ordering is unavailable during the program pause. "
+                                "Orders reopen after %(pause_end)s."
+                            ) % {'pause_end': formats.date_format(in_progress_pause.pause_end, 'DATE_FORMAT')},
+                            'amount_over': 0,
+                            'grace_allowed': False,
+                        })
 
                 # Separate items by category
                 food_items = []

--- a/apps/orders/tests/test_pause_blocks_orders.py
+++ b/apps/orders/tests/test_pause_blocks_orders.py
@@ -1,0 +1,265 @@
+"""
+Program pause blocks ordering during the off week (Issue #78).
+
+Business rules verified:
+  1. While a ProgramPause is in progress, the order window reports
+     'paused' and can_place_order() is False for every program.
+  2. Order creation (the real OrderOrchestration.create_order path used
+     by the participant checkout) is rejected server-side during a pause.
+  3. validate-cart returns a blocking 'window' violation during a pause.
+  4. The pre-pause double-order week (pause 10-14 days out) does NOT
+     block ordering — only the pause week itself does.
+  5. Archived and past pauses do not block.
+  6. A force-open ProgramWindowOverride is the staff escape hatch: it
+     keeps the window open and lets orders through even mid-pause.
+
+The in-progress pause predicate is the raw date range
+(pause_start <= now <= pause_end) — deliberately NOT
+ProgramPause.is_active_gate/multiplier, which match the pre-pause
+double-order week and are falsy during the pause proper.
+"""
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.account.models import AccountBalance
+from apps.lifeskills.models import ProgramPause
+from apps.orders.models import Order
+from apps.orders.tests.factories import (
+    ParticipantFactory,
+    ProductFactory,
+    VoucherFactory,
+    VoucherSettingFactory,
+)
+from apps.orders.utils.order_utils import OrderOrchestration
+from apps.orders.utils.order_validation import OrderItemData, OrderValidation
+from core.models import ProgramWindowOverride
+from core.utils import can_place_order, get_program_window_status
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def voucher_setting():
+    return VoucherSettingFactory(active=True)
+
+
+@pytest.fixture
+def participant():
+    return ParticipantFactory()
+
+
+def create_in_progress_pause(**overrides):
+    """A pause whose off-week is happening right now.
+
+    Uses objects.create() deliberately — clean() forbids creating pauses
+    that start <10 days out, but a real in-progress pause was created in
+    the past and is exactly the state Issue #78 is about.
+    """
+    now = timezone.now()
+    defaults = dict(
+        pause_start=now - timedelta(days=2),
+        pause_end=now + timedelta(days=5),
+        reason='Summer break',
+    )
+    defaults.update(overrides)
+    return ProgramPause.objects.create(**defaults)
+
+
+def fund_account(participant, amount=Decimal('100.00')):
+    account = AccountBalance.objects.get(participant=participant)
+    account.base_balance = amount
+    account.save()
+    VoucherFactory(
+        account=account, state='applied', voucher_type='grocery', multiplier=1
+    )
+    return account
+
+
+# ---------------------------------------------------------------------------
+# Window status / can_place_order
+# ---------------------------------------------------------------------------
+
+class TestWindowStatusDuringPause:
+
+    def test_window_status_is_paused_during_pause(self, participant):
+        pause = create_in_progress_pause()
+        ws = get_program_window_status(participant.program)
+        assert ws['window_status'] == 'paused'
+        expected_seconds = int((pause.pause_end - timezone.now()).total_seconds())
+        assert abs(ws['seconds_until_change'] - expected_seconds) <= 5
+
+    def test_can_place_order_false_during_pause(self, participant):
+        pause = create_in_progress_pause()
+        can_order, context = can_place_order(participant)
+        assert can_order is False
+        assert context['reason'] == 'Program pause in progress'
+        assert context['pause_ends_at'] == pause.pause_end
+
+    def test_pre_pause_double_week_does_not_block(self, participant):
+        """A pause 10-14 days out doubles limits but must NOT close windows."""
+        now = timezone.now()
+        ProgramPause.objects.create(
+            pause_start=now + timedelta(days=12),
+            pause_end=now + timedelta(days=19),
+            reason='Upcoming break',
+        )
+        ws = get_program_window_status(participant.program)
+        assert ws['window_status'] in ('open', 'closed')  # schedule-driven
+
+    def test_archived_pause_does_not_block(self, participant):
+        create_in_progress_pause(archived=True, archived_at=timezone.now())
+        ws = get_program_window_status(participant.program)
+        assert ws['window_status'] != 'paused'
+
+    def test_past_pause_does_not_block(self, participant):
+        now = timezone.now()
+        ProgramPause.objects.create(
+            pause_start=now - timedelta(days=14),
+            pause_end=now - timedelta(days=7),
+            reason='Last month',
+        )
+        ws = get_program_window_status(participant.program)
+        assert ws['window_status'] != 'paused'
+
+    def test_force_open_override_beats_pause(self, participant):
+        create_in_progress_pause()
+        ProgramWindowOverride.objects.create(
+            program=participant.program,
+            force_status='open',
+            expires_at=timezone.now() + timedelta(hours=4),
+            reason='Staff exception during pause',
+        )
+        ws = get_program_window_status(participant.program)
+        assert ws['window_status'] == 'force_open'
+        can_order, _ = can_place_order(participant)
+        assert can_order is True
+
+
+# ---------------------------------------------------------------------------
+# Server-side order creation block
+# ---------------------------------------------------------------------------
+
+class TestOrderCreationDuringPause:
+
+    def test_create_order_rejected_during_pause(self, participant):
+        create_in_progress_pause()
+        account = fund_account(participant)
+        product = ProductFactory(price=Decimal('5.00'), quantity_in_stock=50)
+
+        with pytest.raises(ValidationError, match='program pause'):
+            OrderOrchestration().create_order(
+                account=account,
+                order_items_data=[OrderItemData(product=product, quantity=1)],
+                user=participant.user,
+            )
+        assert not Order.objects.filter(account=account).exists()
+
+    def test_create_order_succeeds_without_pause(self, participant):
+        account = fund_account(participant)
+        product = ProductFactory(price=Decimal('5.00'), quantity_in_stock=50)
+
+        OrderOrchestration().create_order(
+            account=account,
+            order_items_data=[OrderItemData(product=product, quantity=1)],
+            user=participant.user,
+        )
+        assert Order.objects.filter(account=account, status='pending').count() == 1
+
+    def test_force_open_override_lets_order_through_during_pause(self, participant):
+        create_in_progress_pause()
+        ProgramWindowOverride.objects.create(
+            program=participant.program,
+            force_status='open',
+            expires_at=timezone.now() + timedelta(hours=4),
+            reason='Staff exception during pause',
+        )
+        account = fund_account(participant)
+        product = ProductFactory(price=Decimal('5.00'), quantity_in_stock=50)
+
+        OrderOrchestration().create_order(
+            account=account,
+            order_items_data=[OrderItemData(product=product, quantity=1)],
+            user=participant.user,
+        )
+        assert Order.objects.filter(account=account, status='pending').count() == 1
+
+    def test_force_closed_override_does_not_unblock_pause(self, participant):
+        """Only a force-OPEN override is the escape hatch."""
+        create_in_progress_pause()
+        ProgramWindowOverride.objects.create(
+            program=participant.program,
+            force_status='closed',
+            expires_at=timezone.now() + timedelta(hours=4),
+            reason='Closed anyway',
+        )
+        account = fund_account(participant)
+        product = ProductFactory(price=Decimal('5.00'), quantity_in_stock=50)
+
+        with pytest.raises(ValidationError, match='program pause'):
+            OrderOrchestration().create_order(
+                account=account,
+                order_items_data=[OrderItemData(product=product, quantity=1)],
+                user=participant.user,
+            )
+
+    def test_validate_order_items_blocked_directly(self, participant):
+        create_in_progress_pause()
+        account = fund_account(participant)
+        product = ProductFactory(price=Decimal('5.00'), quantity_in_stock=50)
+
+        with pytest.raises(ValidationError, match='program pause'):
+            OrderValidation().validate_order_items(
+                [OrderItemData(product=product, quantity=1)],
+                participant,
+                account,
+            )
+
+
+# ---------------------------------------------------------------------------
+# validate-cart endpoint
+# ---------------------------------------------------------------------------
+
+class TestValidateCartDuringPause:
+    endpoint = '/api/v1/orders/validate-cart/'
+
+    def _post_cart(self, participant, product):
+        client = APIClient()
+        client.force_authenticate(user=participant.user)
+        return client.post(
+            self.endpoint,
+            {'items': [{'product_id': product.id, 'quantity': 1}]},
+            format='json',
+        )
+
+    def test_validate_cart_reports_window_violation_during_pause(self, participant):
+        create_in_progress_pause()
+        fund_account(participant)
+        product = ProductFactory(price=Decimal('5.00'), quantity_in_stock=50)
+
+        response = self._post_cart(participant, product)
+
+        assert response.status_code == 200
+        assert response.data['valid'] is False
+        window_violations = [
+            v for v in response.data['violations'] if v['type'] == 'window'
+        ]
+        assert len(window_violations) == 1
+        assert window_violations[0]['severity'] == 'error'
+
+    def test_validate_cart_has_no_window_violation_without_pause(self, participant):
+        fund_account(participant)
+        product = ProductFactory(price=Decimal('5.00'), quantity_in_stock=50)
+
+        response = self._post_cart(participant, product)
+
+        assert response.status_code == 200
+        assert all(v['type'] != 'window' for v in response.data['violations'])

--- a/apps/orders/utils/order_validation.py
+++ b/apps/orders/utils/order_validation.py
@@ -46,7 +46,46 @@ class OrderValidation:
                 'balance': f"{hygiene_balance:.2f}",
             }
             raise ValidationError(f"[{participant}] {msg}")
-        
+
+    @staticmethod
+    def enforce_program_pause(participant):
+        """Block ordering while a program pause is in progress (Issue #78).
+
+        The pause week is a no-order week for all programs. An unexpired
+        force-open ProgramWindowOverride on the participant's program is
+        the staff escape hatch — it lets orders through even mid-pause.
+        """
+        from core.utils import get_active_window_override, get_in_progress_pause
+
+        in_progress_pause = get_in_progress_pause()
+        if not in_progress_pause:
+            return
+
+        program = getattr(participant, 'program', None)
+        if program is not None:
+            override = get_active_window_override(program)
+            if override and override.force_status == 'open':
+                logger.info(
+                    "[Validator] %s - pause in progress but force-open "
+                    "override active for program %s; allowing order",
+                    participant, program,
+                )
+                return
+
+        from django.utils import formats
+        msg = _(
+            "Ordering is unavailable during the program pause. "
+            "Orders reopen after %(pause_end)s."
+        ) % {'pause_end': formats.date_format(in_progress_pause.pause_end, 'DATE_FORMAT')}
+        logger.warning(
+            "[Validator] %s - order blocked: program pause in progress "
+            "(%s to %s)",
+            participant,
+            in_progress_pause.pause_start,
+            in_progress_pause.pause_end,
+        )
+        raise ValidationError(msg)
+
     # ----------------------------
     # Order items validation
     # ----------------------------
@@ -60,6 +99,7 @@ class OrderValidation:
     ):
         """
         Validate order items in the correct sequence:
+        0. Program pause (ordering blocked during the off week)
         1. Category-level limits
         2. Hygiene balance
         3. Voucher balance
@@ -69,6 +109,9 @@ class OrderValidation:
             return
 
         logger.debug("[Validator] Validating for Participant: %s", participant)
+
+        # Step 0: Block ordering entirely while a program pause is in progress
+        OrderValidation.enforce_program_pause(participant)
 
         # Step 1: Validate category-level limits using CategoryLimitValidator
         CategoryLimitValidator.validate_category_limits(items, participant)

--- a/core/utils.py
+++ b/core/utils.py
@@ -25,6 +25,38 @@ def _parse_meeting_time(meeting_time):
     return meeting_time
 
 
+def get_active_window_override(program, now=None):
+    """Return the program's unexpired ProgramWindowOverride, or None.
+
+    Expired overrides are lazily deleted here (the Celery nightly task
+    handles bulk cleanup).
+    """
+    from core.models import ProgramWindowOverride
+
+    now = now or timezone.now()
+    try:
+        override = program.window_override
+    except ProgramWindowOverride.DoesNotExist:
+        return None
+    if override.expires_at > now:
+        return override
+    override.delete()
+    return None
+
+
+def get_in_progress_pause(now=None):
+    """Return the ProgramPause currently underway, or None.
+
+    ProgramPause is global — during the pause week itself, ordering is
+    blocked for all programs (Issue #78). Uses the raw date range, NOT
+    ProgramPause.is_active_gate/multiplier, which match the pre-pause
+    double-order week and are falsy during the pause proper.
+    """
+    from apps.lifeskills.models import ProgramPause
+
+    return ProgramPause.objects.in_progress(at=now).first()
+
+
 # ---------------------------------------------------------------------------
 # Effective config (COALESCE: per-program override → global singleton)
 # ---------------------------------------------------------------------------
@@ -155,28 +187,26 @@ def get_program_window_status(program) -> dict:
     Compute the complete order-window status for a single program.
 
     Checks for an active ProgramWindowOverride first; if one exists and
-    has not expired it governs the status.  Expired overrides are lazily
-    deleted here (Celery nightly task handles bulk cleanup).
+    has not expired it governs the status — an explicit force-open is the
+    staff escape hatch that beats even a program pause. Otherwise an
+    in-progress ProgramPause closes the window for every program
+    (Issue #78: the pause week is a no-order week).
     """
-    from core.models import ProgramWindowOverride
-
     config = get_effective_config(program)
     now = timezone.now()
 
-    active_override = None
-    try:
-        ov = program.window_override
-        if ov.expires_at > now:
-            active_override = ov
-        else:
-            ov.delete()
-    except ProgramWindowOverride.DoesNotExist:
-        pass
+    active_override = get_active_window_override(program, now)
+    in_progress_pause = get_in_progress_pause(now)
 
     if active_override:
         window_status = f'force_{active_override.force_status}'
         seconds_until_change = max(
             0, int((active_override.expires_at - now).total_seconds())
+        )
+    elif in_progress_pause:
+        window_status = 'paused'
+        seconds_until_change = max(
+            0, int((in_progress_pause.pause_end - now).total_seconds())
         )
     elif not config['enabled']:
         window_status = 'disabled'
@@ -296,17 +326,7 @@ def can_place_order(participant):
     now = timezone.now()
 
     # --- Check for active manual override first ---
-    from core.models import ProgramWindowOverride
-    active_override = None
-    try:
-        ov = program.window_override
-        if ov.expires_at > now:
-            active_override = ov
-        else:
-            ov.delete()
-    except ProgramWindowOverride.DoesNotExist:
-        pass
-
+    active_override = get_active_window_override(program, now)
     if active_override:
         can_order = active_override.force_status == 'open'
         return can_order, {
@@ -320,6 +340,23 @@ def can_place_order(participant):
             'hours_before_close': config['hours_before_close'],
             'can_order': can_order,
             'force_override': active_override.force_status,
+        }
+
+    # --- No override: an in-progress program pause blocks all ordering ---
+    in_progress_pause = get_in_progress_pause(now)
+    if in_progress_pause:
+        return False, {
+            'window_enabled': True,
+            'next_class': get_next_class_datetime(participant),
+            'window_opens': None,
+            'window_closes': None,
+            'hours_until_open': None,
+            'hours_until_close': None,
+            'hours_before_class': config['hours_before_class'],
+            'hours_before_close': config['hours_before_close'],
+            'can_order': False,
+            'reason': 'Program pause in progress',
+            'pause_ends_at': in_progress_pause.pause_end,
         }
 
     # --- No override: check schedule-based window ---

--- a/frontend/src/pages/CoachDashboard.tsx
+++ b/frontend/src/pages/CoachDashboard.tsx
@@ -53,7 +53,7 @@ interface Summary {
 }
 
 interface WindowStatus {
-  window_status: 'open' | 'closed' | 'force_open' | 'force_closed' | 'disabled' | 'no_schedule';
+  window_status: 'open' | 'closed' | 'paused' | 'force_open' | 'force_closed' | 'disabled' | 'no_schedule';
   program_name: string;
   meeting_day: string;
   meeting_time: string;
@@ -71,6 +71,7 @@ interface DashboardData {
 const WINDOW_LABELS: Record<string, string> = {
   open: 'Open',
   closed: 'Closed',
+  paused: 'Paused',
   force_open: 'Force Open',
   force_closed: 'Force Closed',
   disabled: 'Disabled',
@@ -80,6 +81,7 @@ const WINDOW_LABELS: Record<string, string> = {
 const WINDOW_COLORS: Record<string, 'success' | 'default' | 'warning' | 'error' | 'info'> = {
   open: 'success',
   closed: 'default',
+  paused: 'error',
   force_open: 'warning',
   force_closed: 'error',
   disabled: 'info',

--- a/frontend/src/pages/settings/types.ts
+++ b/frontend/src/pages/settings/types.ts
@@ -64,6 +64,7 @@ export interface HygieneSettings {
 export type WindowStatus =
   | 'open'
   | 'closed'
+  | 'paused'
   | 'force_open'
   | 'force_closed'
   | 'disabled'

--- a/frontend/src/pages/settings/utils.ts
+++ b/frontend/src/pages/settings/utils.ts
@@ -9,6 +9,7 @@ export const STATUS_META: Record<
 > = {
   open: { label: 'OPEN', color: 'success' },
   closed: { label: 'CLOSED', color: 'default' },
+  paused: { label: 'PAUSED', color: 'error' },
   force_open: { label: 'FORCE OPEN', color: 'warning' },
   force_closed: { label: 'FORCE CLOSED', color: 'error' },
   disabled: { label: 'DISABLED', color: 'info' },

--- a/frontend/src/resources/programs.tsx
+++ b/frontend/src/resources/programs.tsx
@@ -69,7 +69,7 @@ export const ProgramList = () => (
 // OrderWindowTab — per-program order window status and config inside ProgramShow
 // ---------------------------------------------------------------------------
 
-type WindowStatus = 'open' | 'closed' | 'force_open' | 'force_closed' | 'disabled' | 'no_schedule';
+type WindowStatus = 'open' | 'closed' | 'paused' | 'force_open' | 'force_closed' | 'disabled' | 'no_schedule';
 
 interface WindowCycle { meeting_at: string; opens_at: string; closes_at: string; }
 interface ActiveOverride { id: number; force_status: 'open' | 'closed'; expires_at: string; reason: string; created_by_username: string | null; is_active: boolean; }
@@ -77,10 +77,10 @@ interface EffectiveConfig { hours_before_class: number; hours_before_close: numb
 interface ProgramWindowStatus { program_id: number; program_name: string; meeting_day: string; meeting_time: string; window_status: WindowStatus; cycles: WindowCycle[]; seconds_until_change: number | null; active_order_count: number; override: ActiveOverride | null; config: EffectiveConfig; }
 
 const STATUS_COLORS: Record<WindowStatus, 'success' | 'warning' | 'error' | 'default' | 'info'> = {
-  open: 'success', closed: 'default', force_open: 'warning', force_closed: 'error', disabled: 'info', no_schedule: 'default',
+  open: 'success', closed: 'default', paused: 'error', force_open: 'warning', force_closed: 'error', disabled: 'info', no_schedule: 'default',
 };
 const STATUS_LABELS: Record<WindowStatus, string> = {
-  open: 'OPEN', closed: 'CLOSED', force_open: 'FORCE OPEN', force_closed: 'FORCE CLOSED', disabled: 'DISABLED', no_schedule: 'NO SCHEDULE',
+  open: 'OPEN', closed: 'CLOSED', paused: 'PAUSED', force_open: 'FORCE OPEN', force_closed: 'FORCE CLOSED', disabled: 'DISABLED', no_schedule: 'NO SCHEDULE',
 };
 const fmt = (iso: string) => new Date(iso).toLocaleString(undefined, { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: basketful\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-04 14:13-0400\n"
+"POT-Creation-Date: 2026-07-11 12:18-0400\n"
 "PO-Revision-Date: 2026-07-04 14:13-0400\n"
 "Last-Translator: Basketful Team\n"
 "Language-Team: Spanish\n"
@@ -43,17 +43,26 @@ msgstr "No se encontró el saldo de cuenta de este participante."
 msgid "Product %(product_id)s not found"
 msgstr "No se encontró el producto %(product_id)s"
 
-#: apps/orders/api/views.py:587
+#: apps/orders/api/views.py:567 apps/orders/utils/order_validation.py:76
+#, python-format
+msgid ""
+"Ordering is unavailable during the program pause. Orders reopen after "
+"%(pause_end)s."
+msgstr ""
+"Los pedidos no están disponibles durante la pausa del programa. Los pedidos "
+"se reabren después del %(pause_end)s."
+
+#: apps/orders/api/views.py:608
 #, python-format
 msgid "Food balance exceeded by $%(amount)s"
 msgstr "El saldo de alimentos se excedió por $%(amount)s"
 
-#: apps/orders/api/views.py:602
+#: apps/orders/api/views.py:623
 #, python-format
 msgid "Hygiene balance exceeded by $%(amount)s"
 msgstr "El saldo de higiene se excedió por $%(amount)s"
 
-#: apps/orders/api/views.py:617
+#: apps/orders/api/views.py:638
 #, python-format
 msgid "Go Fresh balance exceeded by $%(amount)s"
 msgstr "El saldo Go Fresh se excedió por $%(amount)s"
@@ -87,8 +96,8 @@ msgid ""
 "Order total $%(total)s exceeds available voucher balance $%(balance)s for "
 "%(participant)s"
 msgstr ""
-"El total del pedido $%(total)s supera el saldo de vales disponible "
-"$%(balance)s de %(participant)s"
+"El total del pedido $%(total)s supera el saldo de vales disponible $"
+"%(balance)s de %(participant)s"
 
 #: apps/orders/utils/order_utils.py:68
 msgid "Cannot create an order with no items."
@@ -102,8 +111,7 @@ msgstr ""
 
 #: apps/orders/utils/order_utils.py:126
 msgid "Another order is being processed. Please wait a moment and try again."
-msgstr ""
-"Se está procesando otro pedido. Espere un momento e intente de nuevo."
+msgstr "Se está procesando otro pedido. Espere un momento e intente de nuevo."
 
 #: apps/orders/utils/order_utils.py:173
 msgid "Order must have at least one valid item."
@@ -113,10 +121,10 @@ msgstr "El pedido debe tener al menos un artículo válido."
 #, python-format
 msgid "Hygiene items total $%(total)s, exceeds hygiene balance $%(balance)s."
 msgstr ""
-"Los artículos de higiene suman $%(total)s, lo que supera el saldo de "
-"higiene de $%(balance)s."
+"Los artículos de higiene suman $%(total)s, lo que supera el saldo de higiene "
+"de $%(balance)s."
 
-#: apps/orders/utils/order_validation.py:89
+#: apps/orders/utils/order_validation.py:131
 #, python-format
 msgid ""
 "Food items total $%(total)s exceeds available voucher balance $%(balance)s."
@@ -124,7 +132,7 @@ msgstr ""
 "Los alimentos suman $%(total)s, lo que supera el saldo de vales disponible "
 "de $%(balance)s."
 
-#: apps/orders/utils/order_validation.py:110
+#: apps/orders/utils/order_validation.py:152
 #, python-format
 msgid ""
 "Food and hygiene items total $%(total)s exceeds available voucher balance $"
@@ -133,21 +141,20 @@ msgstr ""
 "Los alimentos y artículos de higiene suman $%(total)s, lo que supera el "
 "saldo de vales disponible de $%(balance)s."
 
-#: apps/orders/utils/order_validation.py:130
+#: apps/orders/utils/order_validation.py:172
 #, python-format
 msgid "Go Fresh items total $%(total)s exceeds Go Fresh balance $%(balance)s."
 msgstr ""
-"Los artículos Go Fresh suman $%(total)s, lo que supera el saldo Go Fresh "
-"de $%(balance)s."
+"Los artículos Go Fresh suman $%(total)s, lo que supera el saldo Go Fresh de $"
+"%(balance)s."
 
-#: apps/orders/utils/order_validation.py:145
+#: apps/orders/utils/order_validation.py:187
 #, python-format
 msgid "%(product)s: requested %(requested)d, only %(available)d in stock"
 msgstr ""
-"%(product)s: se pidieron %(requested)d, solo hay %(available)d en "
-"existencia"
+"%(product)s: se pidieron %(requested)d, solo hay %(available)d en existencia"
 
-#: apps/orders/utils/order_validation.py:155
+#: apps/orders/utils/order_validation.py:197
 #, python-format
 msgid "Insufficient stock: %(detail)s"
 msgstr "Existencias insuficientes: %(detail)s"
@@ -168,55 +175,55 @@ msgstr ""
 msgid "View on site"
 msgstr ""
 
-#: apps/pantry/models.py:393
+#: apps/pantry/models.py:440
 msgid "Subcategory"
 msgstr "Subcategoría"
 
-#: apps/pantry/models.py:394
+#: apps/pantry/models.py:441
 msgid "Category"
 msgstr "Categoría"
 
-#: apps/pantry/models.py:406
+#: apps/pantry/models.py:453
 #, python-format
 msgid "%(product)s (qty: %(quantity)d)"
 msgstr "%(product)s (cant.: %(quantity)d)"
 
-#: apps/pantry/models.py:420
+#: apps/pantry/models.py:467
 #, python-format
 msgid "%(count)d adult"
 msgid_plural "%(count)d adults"
 msgstr[0] "%(count)d adulto"
 msgstr[1] "%(count)d adultos"
 
-#: apps/pantry/models.py:423
+#: apps/pantry/models.py:470
 #, python-format
 msgid "%(count)d child"
 msgid_plural "%(count)d children"
 msgstr[0] "%(count)d niño"
 msgstr[1] "%(count)d niños"
 
-#: apps/pantry/models.py:426
+#: apps/pantry/models.py:473
 #, python-format
 msgid "%(count)d infant"
 msgid_plural "%(count)d infants"
 msgstr[0] "%(count)d bebé"
 msgstr[1] "%(count)d bebés"
 
-#: apps/pantry/models.py:428
+#: apps/pantry/models.py:475
 #, python-format
 msgid "household of %(size)d"
 msgstr "hogar de %(size)d"
 
-#: apps/pantry/models.py:431
+#: apps/pantry/models.py:478
 msgid "per order"
 msgstr "por pedido"
 
-#: apps/pantry/models.py:436
+#: apps/pantry/models.py:483
 #, python-format
 msgid "%(limit)d (%(paused_limit)d with %(multiplier)dx pause)"
 msgstr "%(limit)d (%(paused_limit)d con pausa de %(multiplier)dx)"
 
-#: apps/pantry/models.py:445
+#: apps/pantry/models.py:492
 #, python-format
 msgid ""
 "Limit exceeded for %(category_type)s '%(category)s' (scope: %(scope)s, "
@@ -224,8 +231,8 @@ msgid ""
 "allowed %(allowed)d. Products: %(product_list)s"
 msgstr ""
 "Límite excedido para la %(category_type)s '%(category)s' (alcance: "
-"%(scope)s, límite: %(limit_description)s %(scope_description)s): Se "
-"pidieron %(ordered)d, se permiten %(allowed)d. Productos: %(product_list)s"
+"%(scope)s, límite: %(limit_description)s %(scope_description)s): Se pidieron "
+"%(ordered)d, se permiten %(allowed)d. Productos: %(product_list)s"
 
 #: apps/pantry/templates/admin/base_site.html:4
 msgid "Django site admin"

--- a/participant-frontend/src/features/orders/CheckoutPage.tsx
+++ b/participant-frontend/src/features/orders/CheckoutPage.tsx
@@ -184,6 +184,8 @@ export const CheckoutPage: React.FC = () => {
             ? t('checkout.windowForceClosed')
             : windowStatus === 'no_schedule'
             ? t('checkout.windowNoSchedule')
+            : windowStatus === 'paused'
+            ? t('checkout.windowPaused')
             : t('checkout.windowClosed')}
         </Alert>
       )}

--- a/participant-frontend/src/locales/en.json
+++ b/participant-frontend/src/locales/en.json
@@ -117,6 +117,7 @@
       "windowForceClosed": "Order window is temporarily closed",
       "windowDisabled": "Order window is not enabled",
       "windowNoSchedule": "No class schedule found",
+      "windowPaused": "The program is on pause this week",
       "windowClosed": "Order window is closed",
       "fixCartErrors": "Please fix cart errors",
       "cartInvalid": "Cart is not valid"
@@ -133,6 +134,7 @@
     "emptySubtitle": "Add some products before checking out.",
     "windowForceClosed": "Orders are temporarily paused. Please try again later.",
     "windowNoSchedule": "No class schedule found for your program. Please contact staff.",
+    "windowPaused": "The program is on pause this week. Ordering will reopen after the break.",
     "windowClosed": "The order window is currently closed. You cannot submit orders at this time.",
     "orderSummary": "Order Summary",
     "quantity": "Qty: {{count}}",

--- a/participant-frontend/src/locales/es.json
+++ b/participant-frontend/src/locales/es.json
@@ -117,6 +117,7 @@
       "windowForceClosed": "El período de pedidos está cerrado temporalmente",
       "windowDisabled": "El período de pedidos no está habilitado",
       "windowNoSchedule": "No se encontró un horario de clases",
+      "windowPaused": "El programa está en pausa esta semana",
       "windowClosed": "El período de pedidos está cerrado",
       "fixCartErrors": "Por favor, corrija los errores del carrito",
       "cartInvalid": "El carrito no es válido"
@@ -133,6 +134,7 @@
     "emptySubtitle": "Agregue algunos productos antes de finalizar el pedido.",
     "windowForceClosed": "Los pedidos están pausados temporalmente. Intente de nuevo más tarde.",
     "windowNoSchedule": "No se encontró un horario de clases para su programa. Comuníquese con el personal.",
+    "windowPaused": "El programa está en pausa esta semana. Los pedidos se reabrirán después del receso.",
     "windowClosed": "El período de pedidos está cerrado. No puede enviar pedidos en este momento.",
     "orderSummary": "Resumen del pedido",
     "quantity": "Cant.: {{count}}",

--- a/participant-frontend/src/providers/ValidationContext.tsx
+++ b/participant-frontend/src/providers/ValidationContext.tsx
@@ -223,6 +223,7 @@ export type CheckoutBlockedReasonKey =
   | 'validation.blocked.windowForceClosed'
   | 'validation.blocked.windowDisabled'
   | 'validation.blocked.windowNoSchedule'
+  | 'validation.blocked.windowPaused'
   | 'validation.blocked.windowClosed'
   | 'validation.blocked.fixCartErrors'
   | 'validation.blocked.cartInvalid';
@@ -251,6 +252,7 @@ export const useCanCheckout = () => {
       if (windowStatus === 'force_closed') return 'validation.blocked.windowForceClosed';
       if (windowStatus === 'disabled') return 'validation.blocked.windowDisabled';
       if (windowStatus === 'no_schedule') return 'validation.blocked.windowNoSchedule';
+      if (windowStatus === 'paused') return 'validation.blocked.windowPaused';
       return 'validation.blocked.windowClosed';
     }
     if (errors.length > 0) return 'validation.blocked.fixCartErrors';

--- a/participant-frontend/src/shared/types/api.ts
+++ b/participant-frontend/src/shared/types/api.ts
@@ -155,6 +155,7 @@ export interface OrderWindowStatus {
 export type WindowStatusCode =
   | 'open'
   | 'closed'
+  | 'paused'
   | 'force_open'
   | 'force_closed'
   | 'disabled'


### PR DESCRIPTION
## Summary
- Fixes #78: participants placed orders during last week's program pause. Ordering is now blocked while a pause is in progress — and **only** then; the pre-pause double-order week and normal windows are unchanged.
- Root cause: no code in the order path ever asked "is a pause happening right now?". The window engine computed cycles purely from the meeting schedule (windows kept opening through the off week), and the DRF creation path never consulted the window at all — the only gate was in the frontend.

## Changes
- **`ProgramPause.objects.in_progress()`** — the raw `pause_start <= now <= pause_end` predicate. Deliberately *not* `is_active_gate`/`multiplier`, which match the pre-pause double-order week and are falsy during the pause proper. The order-window notification task now shares it instead of an inline copy.
- **Window engine**: `get_program_window_status` / `can_place_order` report a new `paused` status during a pause, with the countdown pointing at `pause_end`. Also extracted the duplicated override lookup into `get_active_window_override()`.
- **Server-side hard block**: `validate_order_items` step 0 rejects orders during a pause, so `OrderOrchestration.create_order` (the real checkout path) is protected even against direct API calls. `validate-cart` now emits the blocking `type: "window"` violation its docstring always advertised.
- **Staff escape hatch**: an unexpired **force-open** `ProgramWindowOverride` beats the pause (force-closed does not un-block), consistent with overrides outranking the schedule everywhere else.
- **Frontends**: participant checkout shows a translated "program is on pause this week" banner (en/es) and the submit button disables; admin order-window dashboard, program window tab, and coach dashboard render a `PAUSED` chip.
- **i18n**: backend error localized with a locale-aware date — *"Los pedidos se reabren después del 17 de julio de 2026."*

## Test plan
- [x] 13 new tests in `apps/orders/tests/test_pause_blocks_orders.py`: window reports `paused` / `can_place_order` false during a pause; pre-pause double week does **not** block; archived and past pauses ignored; `create_order` rejected mid-pause and clean without one; force-open override lets orders through, force-closed doesn't; `validate_order_items` blocks directly; validate-cart emits exactly one blocking window violation
- [x] Full backend suite: 545 passed (1 pre-existing failure on main in `test_account_setup.py`, unrelated)
- [x] Both frontends: typecheck, lint, and all tests pass
- [x] Manual dev-shell run: status flips to `paused`, order creation raises the translated error in both languages, everything reopens when the pause ends

## Deploy notes
- No migrations. Backend should deploy before/with the frontends so the `paused` status exists when the UI asks for it (older frontends degrade gracefully — `is_open: false` already blocks checkout).

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)