### PR TITLE
fix: email tests failed in CI after a TransactionTestCase flushed seeded rows

### DIFF
--- a/apps/log/tests/conftest.py
+++ b/apps/log/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Shared fixtures for apps/log tests.
+
+The email tests assert against the EmailType rows seeded by data
+migrations. Data-migration rows do NOT survive a database flush: any
+TransactionTestCase in the suite (e.g. apps/lifeskills/tests/
+test_program_pause.py) truncates all tables when it finishes, so tests
+that run after it see an empty EmailType table — locally the ordering
+may hide this, in CI it surfaced as EmailType.DoesNotExist.
+
+Per the project convention (see CLAUDE.md: create test data explicitly,
+never rely on database state), `seeded_email_types` re-runs the actual
+migration seed functions when the rows are missing. Reusing the real
+migration code keeps the content byte-identical to production, so the
+wording-migration assertions still test the real thing.
+"""
+import importlib
+
+import pytest
+from django.apps import apps as django_apps
+
+
+def _migration(name):
+    return importlib.import_module(f'apps.log.migrations.{name}')
+
+
+@pytest.fixture
+def seeded_email_types(db):
+    """Ensure the migration-seeded EmailType rows exist."""
+    from apps.log.models import EmailType
+
+    if not EmailType.objects.filter(name='onboarding').exists():
+        _migration('0005_seed_email_types').seed_email_types(django_apps, None)
+        _migration('0011_fix_email_template_escaped_quotes').fix_email_templates(django_apps, None)
+        _migration('0017_onboarding_email_username_wording').apply_username_wording(django_apps, None)
+    if not EmailType.objects.filter(name='order_window_opened').exists():
+        _migration('0011_seed_order_window_opened_email_type').seed_order_window_opened_email_type(django_apps, None)
+    if not EmailType.objects.filter(name='low_inventory_alert').exists():
+        _migration('0016_seed_low_inventory_alert_email_type').seed_low_inventory_alert_email_type(django_apps, None)

--- a/apps/log/tests/test_email_studio.py
+++ b/apps/log/tests/test_email_studio.py
@@ -18,6 +18,11 @@ User = get_user_model()
 
 pytestmark = pytest.mark.django_db
 
+
+@pytest.fixture(autouse=True)
+def _email_types(seeded_email_types):
+    """Migration-seeded EmailTypes, resilient to DB flushes (see conftest)."""
+
 SAMPLE_DESIGN = {
     'root': {
         'type': 'EmailLayout',

--- a/apps/log/tests/test_email_variables_and_preview.py
+++ b/apps/log/tests/test_email_variables_and_preview.py
@@ -30,6 +30,11 @@ User = get_user_model()
 pytestmark = pytest.mark.django_db
 
 
+@pytest.fixture(autouse=True)
+def _email_types(seeded_email_types):
+    """Migration-seeded EmailTypes, resilient to DB flushes (see conftest)."""
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- CI failed with 18 × `EmailType.DoesNotExist` in the new email studio/preview tests
- Root cause: those tests relied on the **data-migration-seeded** EmailType rows, but `apps/lifeskills/tests/test_program_pause.py` is a `TransactionTestCase` — when it finishes, Django **flushes the database**, wiping migration-seeded rows for every test that runs after it. Local ordering hid the problem; CI's ordering exposed it.
- Fix: a `seeded_email_types` fixture (`apps/log/tests/conftest.py`, autouse in the two affected files) that re-runs the actual migration seed functions when the rows are missing. Reusing the real migration code keeps content byte-identical to production, so the wording-migration assertions still verify the real migration output. This follows the repo convention: tests create their data explicitly, never rely on DB state.

## Test plan
- [x] Reproduced CI's failure locally: `pytest apps/lifeskills/tests/test_program_pause.py apps/log/tests/test_email_studio.py` → 7 failed before the fix, all pass after
- [x] Flush-first ordering across both affected files: 36/36 pass
- [x] Full backend suite: 571 passed (1 pre-existing local-only failure in `test_account_setup.py`, unrelated and not failing in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)