### PR TITLE
style: fix flake8 E305 in email studio tests

### DIFF
--- a/apps/log/tests/test_email_studio.py
+++ b/apps/log/tests/test_email_studio.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.django_db
 def _email_types(seeded_email_types):
     """Migration-seeded EmailTypes, resilient to DB flushes (see conftest)."""
 
+
 SAMPLE_DESIGN = {
     'root': {
         'type': 'EmailLayout',


### PR DESCRIPTION
One-line lint fix: two blank lines after the autouse fixture introduced in #87. `flake8 apps/ core/` is clean locally and the file's tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)