### PR TITLE
feat: resizable studio panels, personalized test sends, settings fixes

### DIFF
--- a/apps/log/api/views.py
+++ b/apps/log/api/views.py
@@ -129,6 +129,10 @@ class EmailTypeViewSet(viewsets.ModelViewSet):
             )
 
         context = email_type.get_sample_context_for_type()
+        # Test sends render with the requesting user's real details (name,
+        # username, email) instead of the sample participant, so the email
+        # you receive reads as it would for you.
+        context['user'] = request.user
         with translation.override(language):
             try:
                 subject_draft = request.data.get('subject')

--- a/apps/log/tests/test_email_studio.py
+++ b/apps/log/tests/test_email_studio.py
@@ -39,7 +39,8 @@ SAMPLE_DESIGN = {
 @pytest.fixture
 def staff_user():
     return User.objects.create_user(
-        username='studio-staff', email='studio@example.com', is_staff=True
+        username='studio-staff', email='studio@example.com',
+        first_name='Studio', is_staff=True,
     )
 
 
@@ -98,7 +99,9 @@ class TestSendTest:
         assert len(mail.outbox) == 1
         message = mail.outbox[0]
         assert message.to == [staff_user.email]
-        assert message.subject == '[TEST] Draft subject for Maria'
+        # Test sends render with the requesting user's real details, not
+        # the sample participant.
+        assert message.subject == '[TEST] Draft subject for Studio'
         assert 'C-BKM-7' in message.alternatives[0][0]
 
         log_entry = EmailLog.objects.get(user=staff_user, is_test=True)

--- a/apps/log/tests/test_email_variables_and_preview.py
+++ b/apps/log/tests/test_email_variables_and_preview.py
@@ -256,6 +256,25 @@ class TestEmailSettingsUrlOverrides:
         assert persisted.participant_frontend_url == 'https://shop.copied.org'
         assert persisted.backend_domain == 'api.copied.org'
 
+    def test_scheme_less_participant_url_is_normalized(self):
+        """Staff can type a bare domain — the serializer assumes https."""
+        client = APIClient()
+        client.force_authenticate(
+            user=User.objects.create_user(
+                username='url-staff', email='url@example.com', is_staff=True
+            )
+        )
+        response = client.patch(
+            '/api/v1/settings/email-settings/current/',
+            {'participant_frontend_url': 'shop.wedgwood.org'},
+            format='json',
+        )
+        assert response.status_code == 200
+        assert (
+            EmailSettings.get_settings().participant_frontend_url
+            == 'https://shop.wedgwood.org'
+        )
+
     def test_build_email_context_uses_backend_domain_override(self):
         email_settings = EmailSettings.get_settings()
         email_settings.backend_domain = 'emails.example.org'

--- a/core/api/serializers.py
+++ b/core/api/serializers.py
@@ -103,6 +103,15 @@ class EmailSettingsSerializer(serializers.ModelSerializer):
     effective_participant_frontend_url = serializers.SerializerMethodField()
     effective_backend_domain = serializers.SerializerMethodField()
 
+    def to_internal_value(self, data):
+        # Staff type bare domains ("shop.example.org"); URLField would
+        # reject them with a 400. Assume https when no scheme is given.
+        data = data.copy()
+        url = data.get('participant_frontend_url')
+        if isinstance(url, str) and url and '://' not in url:
+            data['participant_frontend_url'] = f'https://{url}'
+        return super().to_internal_value(data)
+
     class Meta:
         model = EmailSettings
         fields = [

--- a/frontend/src/AdminApp.tsx
+++ b/frontend/src/AdminApp.tsx
@@ -154,7 +154,7 @@ const CustomMenu = () => (
     <Menu.ResourceItem name="permissions" />
     <Menu.ResourceItem name="coaches" />
     <Menu.Item to="/coach-dashboard" primaryText="Coach Dashboard" leftIcon={<DashboardCustomizeIcon />} />
-    <Menu.Item to="/branding-settings/current/edit" primaryText="Branding" leftIcon={<BrandingSettingsIcon />} />
+    <Menu.Item to="/settings/branding-settings/current/edit" primaryText="Branding" leftIcon={<BrandingSettingsIcon />} />
     <Menu.Item to="/settings" primaryText="Settings" leftIcon={<SettingsIcon />} />
     <Menu.Item to="/email-types" primaryText="Email Types" leftIcon={<EmailIcon />} />
     <Menu.Item to="/email-logs" primaryText="Email Logs" leftIcon={<ArticleIcon />} />
@@ -356,7 +356,7 @@ const App = () => (
 
     {/* Branding Settings (singleton — edit only) */}
     <Resource
-      name="branding-settings"
+      name="settings/branding-settings"
       edit={BrandingSettingsEdit}
       icon={BrandingSettingsIcon}
       options={{ label: 'Branding' }}

--- a/frontend/src/emailStudio/EmailStudioEditor.tsx
+++ b/frontend/src/emailStudio/EmailStudioEditor.tsx
@@ -28,6 +28,7 @@ import {
 } from './vendor/documents/editor/EditorContext';
 import type { TEditorConfiguration } from './vendor/documents/editor/core';
 import InspectorDrawer from './vendor/App/InspectorDrawer';
+import ToggleInspectorPanelButton from './vendor/App/InspectorDrawer/ToggleInspectorPanelButton';
 
 export type { TEditorConfiguration };
 export { EMPTY_EMAIL_MESSAGE };
@@ -102,6 +103,7 @@ export const EmailStudioEditor = ({
               </Tooltip>
             </ToggleButton>
           </ToggleButtonGroup>
+          <ToggleInspectorPanelButton />
         </Stack>
         <Box sx={{ flex: 1, overflow: 'auto', bgcolor: '#f5f5f5' }}>
           <Box sx={canvasSx}>

--- a/frontend/src/emailStudio/EmailStudioPage.tsx
+++ b/frontend/src/emailStudio/EmailStudioPage.tsx
@@ -19,6 +19,9 @@ import SendIcon from '@mui/icons-material/Send';
 import SaveIcon from '@mui/icons-material/Save';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import DataObjectIcon from '@mui/icons-material/DataObject';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import CloseIcon from '@mui/icons-material/Close';
+import MenuOpenIcon from '@mui/icons-material/MenuOpen';
 import {
   Alert,
   Box,
@@ -45,6 +48,12 @@ import {
 import apiClient from '../lib/api/apiClient';
 import { EmailServerPreview } from '../resources/logs/EmailServerPreview';
 import { EmailStudioEditor } from './EmailStudioEditor';
+import {
+  LEFT_PANEL,
+  PREVIEW_PANEL,
+  startPanelDrag,
+  usePersistentState,
+} from './panelLayout';
 import { VariablesPanel, type EmailVariableInfo } from './VariablesPanel';
 import { TEMPLATE_PRESETS } from './templatePresets';
 import {
@@ -67,7 +76,10 @@ export const EmailStudioPage = () => {
   const [language, setLanguage] = useState<StudioLanguage>('en');
   const [drafts, setDrafts] = useState<Record<StudioLanguage, LanguageDraft> | null>(null);
   const [modes, setModes] = useState<Record<StudioLanguage, StudioMode> | null>(null);
-  const [showPreview, setShowPreview] = useState(true);
+  const [showPreview, setShowPreview] = usePersistentState('emailStudio.showPreview', true);
+  const [showLeftPanel, setShowLeftPanel] = usePersistentState('emailStudio.showLeftPanel', true);
+  const [leftWidth, setLeftWidth] = usePersistentState('emailStudio.leftWidth', LEFT_PANEL.initial);
+  const [previewWidth, setPreviewWidth] = usePersistentState('emailStudio.previewWidth', PREVIEW_PANEL.initial);
   const [confirmCodeSaveOpen, setConfirmCodeSaveOpen] = useState(false);
   const [sendingTest, setSendingTest] = useState(false);
   const [variableMenuAnchor, setVariableMenuAnchor] = useState<null | HTMLElement>(null);
@@ -266,8 +278,19 @@ export const EmailStudioPage = () => {
 
       {/* ── Main area ───────────────────────────────────────────────── */}
       <Stack direction="row" sx={{ flex: 1, minHeight: 0, border: 1, borderColor: 'divider' }}>
-        {/* Left panel: presets + variables */}
-        <Box sx={{ width: 280, flexShrink: 0, borderRight: 1, borderColor: 'divider', overflow: 'auto' }}>
+        {/* Left panel: presets + variables (dismissable, resizable) */}
+        {showLeftPanel ? (
+        <Box sx={{ width: leftWidth, flexShrink: 0, borderRight: 1, borderColor: 'divider', overflow: 'auto', position: 'relative' }}>
+          <Tooltip title="Hide panel">
+            <IconButton
+              size="small"
+              onClick={() => setShowLeftPanel(false)}
+              sx={{ position: 'absolute', top: 4, right: 4 }}
+              aria-label="Hide variables panel"
+            >
+              <ChevronLeftIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
           <Typography variant="subtitle2" sx={{ px: 2, pt: 2 }}>Start from…</Typography>
           <Stack spacing={1} sx={{ p: 2 }}>
             {TEMPLATE_PRESETS.map(preset => (
@@ -287,6 +310,29 @@ export const EmailStudioPage = () => {
           <Divider />
           <VariablesPanel variables={variables} />
         </Box>
+        ) : (
+          <Box sx={{ borderRight: 1, borderColor: 'divider', display: 'flex', alignItems: 'flex-start' }}>
+            <Tooltip title="Show templates & variables">
+              <IconButton size="small" onClick={() => setShowLeftPanel(true)} aria-label="Show variables panel">
+                <MenuOpenIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        )}
+        {showLeftPanel && (
+          <Box
+            onMouseDown={e =>
+              startPanelDrag(e.clientX, leftWidth, 1, LEFT_PANEL, setLeftWidth)
+            }
+            sx={{
+              width: 6,
+              flexShrink: 0,
+              cursor: 'col-resize',
+              '&:hover': { bgcolor: 'primary.light' },
+            }}
+            data-testid="left-panel-resizer"
+          />
+        )}
 
         {/* Editor */}
         <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
@@ -316,11 +362,35 @@ export const EmailStudioPage = () => {
           )}
         </Box>
 
-        {/* Live preview */}
+        {/* Live preview (dismissable, resizable) */}
         {showPreview && (
-          <Box sx={{ width: '38%', flexShrink: 0, borderLeft: 1, borderColor: 'divider', overflow: 'auto', p: 1 }}>
-            <EmailServerPreview emailTypeId={record.id} draft={previewDraft} />
-          </Box>
+          <>
+            <Box
+              onMouseDown={e =>
+                startPanelDrag(e.clientX, previewWidth, -1, PREVIEW_PANEL, setPreviewWidth)
+              }
+              sx={{
+                width: 6,
+                flexShrink: 0,
+                cursor: 'col-resize',
+                '&:hover': { bgcolor: 'primary.light' },
+              }}
+              data-testid="preview-resizer"
+            />
+            <Box sx={{ width: previewWidth, flexShrink: 0, borderLeft: 1, borderColor: 'divider', overflow: 'auto', p: 1, position: 'relative' }}>
+              <Tooltip title="Hide preview">
+                <IconButton
+                  size="small"
+                  onClick={() => setShowPreview(false)}
+                  sx={{ position: 'absolute', top: 4, right: 4, zIndex: 1 }}
+                  aria-label="Hide preview"
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <EmailServerPreview emailTypeId={record.id} draft={previewDraft} />
+            </Box>
+          </>
         )}
       </Stack>
 

--- a/frontend/src/emailStudio/__tests__/panelLayout.test.ts
+++ b/frontend/src/emailStudio/__tests__/panelLayout.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for the studio's panel layout helpers.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { LEFT_PANEL, PREVIEW_PANEL, clampWidth, startPanelDrag } from '../panelLayout';
+
+describe('clampWidth', () => {
+  it('clamps to the panel bounds', () => {
+    expect(clampWidth(50, LEFT_PANEL)).toBe(LEFT_PANEL.min);
+    expect(clampWidth(9999, LEFT_PANEL)).toBe(LEFT_PANEL.max);
+    expect(clampWidth(300, LEFT_PANEL)).toBe(300);
+  });
+});
+
+describe('startPanelDrag', () => {
+  const drag = (clientX: number) =>
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX }));
+  const release = () => window.dispatchEvent(new MouseEvent('mouseup'));
+
+  it('grows a left panel when dragging right (direction +1)', () => {
+    const onResize = vi.fn();
+    startPanelDrag(100, 280, 1, LEFT_PANEL, onResize);
+    drag(150);
+    expect(onResize).toHaveBeenLastCalledWith(330);
+    release();
+  });
+
+  it('shrinks a right panel when dragging right (direction -1)', () => {
+    const onResize = vi.fn();
+    startPanelDrag(100, PREVIEW_PANEL.initial, -1, PREVIEW_PANEL, onResize);
+    drag(160);
+    expect(onResize).toHaveBeenLastCalledWith(PREVIEW_PANEL.initial - 60);
+    release();
+  });
+
+  it('stops resizing after mouseup and respects bounds while dragging', () => {
+    const onResize = vi.fn();
+    startPanelDrag(0, 280, 1, LEFT_PANEL, onResize);
+    drag(-10_000);
+    expect(onResize).toHaveBeenLastCalledWith(LEFT_PANEL.min);
+    release();
+    onResize.mockClear();
+    drag(500);
+    expect(onResize).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/emailStudio/panelLayout.ts
+++ b/frontend/src/emailStudio/panelLayout.ts
@@ -1,0 +1,66 @@
+/**
+ * Panel layout state for the Email Design Studio: persisted, clamped
+ * widths and open/closed flags for the left (variables/presets) panel
+ * and the preview panel. Kept React-free where possible so the clamp
+ * logic is unit-testable.
+ */
+import { useState } from 'react';
+
+export const LEFT_PANEL = { min: 200, max: 520, initial: 280 };
+export const PREVIEW_PANEL = { min: 300, max: 900, initial: 480 };
+
+export const clampWidth = (
+  value: number,
+  bounds: { min: number; max: number }
+): number => Math.min(bounds.max, Math.max(bounds.min, value));
+
+export function usePersistentState<T>(
+  key: string,
+  initial: T
+): [T, (value: T) => void] {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw !== null ? (JSON.parse(raw) as T) : initial;
+    } catch {
+      return initial;
+    }
+  });
+  const set = (next: T) => {
+    setValue(next);
+    try {
+      localStorage.setItem(key, JSON.stringify(next));
+    } catch {
+      // Persistence is best-effort; never break the UI over storage.
+    }
+  };
+  return [value, set];
+}
+
+/**
+ * Start a horizontal drag-resize. `direction` is +1 when dragging right
+ * grows the panel (left-side panels) and -1 when dragging right shrinks
+ * it (right-side panels).
+ */
+export const startPanelDrag = (
+  startClientX: number,
+  startWidth: number,
+  direction: 1 | -1,
+  bounds: { min: number; max: number },
+  onResize: (width: number) => void
+) => {
+  const onMove = (event: MouseEvent) => {
+    const delta = (event.clientX - startClientX) * direction;
+    onResize(clampWidth(startWidth + delta, bounds));
+  };
+  const onUp = () => {
+    window.removeEventListener('mousemove', onMove);
+    window.removeEventListener('mouseup', onUp);
+    document.body.style.removeProperty('cursor');
+    document.body.style.removeProperty('user-select');
+  };
+  window.addEventListener('mousemove', onMove);
+  window.addEventListener('mouseup', onUp);
+  document.body.style.cursor = 'col-resize';
+  document.body.style.userSelect = 'none';
+};

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -24,6 +24,17 @@ import type {
   VoucherSettings,
 } from './settings/types';
 
+/** Turn a DRF validation error into a readable message, e.g. "participant_frontend_url: Enter a valid URL." */
+const describeApiError = (err: unknown): string | null => {
+  const data = (err as { response?: { data?: unknown } })?.response?.data;
+  if (!data || typeof data !== 'object') return null;
+  const parts = Object.entries(data as Record<string, unknown>).map(
+    ([field, messages]) =>
+      `${field}: ${Array.isArray(messages) ? messages.join(' ') : String(messages)}`
+  );
+  return parts.length ? parts.join(' — ') : null;
+};
+
 export const Settings = () => {
   const dataProvider = useDataProvider();
   const notify = useNotify();
@@ -90,8 +101,8 @@ export const Settings = () => {
       });
       setOrderWindow(data);
       notify('Order window settings saved', { type: 'success' });
-    } catch {
-      notify('Error saving settings', { type: 'error' });
+    } catch (err) {
+      notify(describeApiError(err) ?? 'Error saving settings', { type: 'error' });
     }
     setSaving(false);
   };
@@ -106,8 +117,8 @@ export const Settings = () => {
         previousData: email,
       });
       notify('Email settings saved', { type: 'success' });
-    } catch {
-      notify('Error saving settings', { type: 'error' });
+    } catch (err) {
+      notify(describeApiError(err) ?? 'Error saving settings', { type: 'error' });
     }
     setSaving(false);
   };
@@ -122,8 +133,8 @@ export const Settings = () => {
         previousData: branding,
       });
       notify('Branding settings saved', { type: 'success' });
-    } catch {
-      notify('Error saving settings', { type: 'error' });
+    } catch (err) {
+      notify(describeApiError(err) ?? 'Error saving settings', { type: 'error' });
     }
     setSaving(false);
   };
@@ -138,8 +149,8 @@ export const Settings = () => {
         previousData: voucher,
       });
       notify('Voucher settings saved', { type: 'success' });
-    } catch {
-      notify('Error saving settings', { type: 'error' });
+    } catch (err) {
+      notify(describeApiError(err) ?? 'Error saving settings', { type: 'error' });
     }
     setSaving(false);
   };
@@ -154,8 +165,8 @@ export const Settings = () => {
         previousData: hygiene,
       });
       notify('Hygiene settings saved', { type: 'success' });
-    } catch {
-      notify('Error saving settings', { type: 'error' });
+    } catch (err) {
+      notify(describeApiError(err) ?? 'Error saving settings', { type: 'error' });
     }
     setSaving(false);
   };
@@ -170,8 +181,8 @@ export const Settings = () => {
         previousData: inventoryAlerts,
       });
       notify('Inventory alert settings saved', { type: 'success' });
-    } catch {
-      notify('Error saving settings', { type: 'error' });
+    } catch (err) {
+      notify(describeApiError(err) ?? 'Error saving settings', { type: 'error' });
     }
     setSaving(false);
   };

--- a/frontend/src/resources/brandingSettings.tsx
+++ b/frontend/src/resources/brandingSettings.tsx
@@ -1,6 +1,8 @@
 /**
  * Branding Settings — singleton resource.
- * Nav link goes directly to /branding-settings/current/edit, bypassing the list.
+ * Nav link goes directly to /settings/branding-settings/current/edit, bypassing
+ * the list. The resource name carries the settings/ prefix so react-admin's
+ * record load hits the real API path (/api/v1/settings/branding-settings/).
  */
 import {
   Edit,
@@ -60,7 +62,7 @@ export const BrandingSettingsEdit = () => {
 
   return (
     <Edit
-      resource="branding-settings"
+      resource="settings/branding-settings"
       id="current"
       mutationMode="pessimistic"
       mutationOptions={{ onSuccess: () => notify('Branding settings saved', { type: 'success' }) }}


### PR DESCRIPTION
## Summary

**Studio UX** (owner feedback from first hands-on use):
- **Every panel is now dismissable and the layout is redistributable**: the left presets/variables panel collapses to a thin rail and drag-resizes (200–520px); the live preview closes via X or the toolbar eye and drag-resizes (300–900px); the block inspector toggles via the vendored button. Widths and visibility persist per browser (localStorage).
- **Send test personalization**: `{{ user.* }}` now renders with the requesting staff user's real name/username/email instead of the sample participant — the test email you receive reads as it would for you. (Delivery was already to your own address.)

**Settings fixes** (from the prod console errors):
- Saving Email Settings 400'd when the Participant App URL was typed without `https://` — the serializer now assumes https for bare domains, and all Settings save toasts surface the actual DRF field error (e.g. `participant_frontend_url: Enter a valid URL.`) instead of a generic message.
- **Branding page load 404 (pre-existing)**: the react-admin resource pointed at `/api/v1/branding-settings/` but the API lives under `/api/v1/settings/branding-settings/`. Resource renamed to carry the prefix — the Branding edit page loads its record again.

## Test plan
- [x] Backend: log suites 73 passed incl. new scheme-normalization API test and updated personalized send-test assertions; flake8 clean
- [x] Frontend: tsc clean, lint clean, 45 vitest passed (4 new panel-layout drag/clamp tests)
- [x] Playwright e2e: 5/5 passed against the live stack with the reworked layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)